### PR TITLE
Textfield for the quantity in Product Detail View and cartItemView + Add "added to cart" view on top of the product detail view

### DIFF
--- a/ShopHub/ShopHub.xcodeproj/project.pbxproj
+++ b/ShopHub/ShopHub.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		AEBD622F2A99A1E10014C335 /* CartItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBD622E2A99A1E10014C335 /* CartItemView.swift */; };
 		AEC27B292AACDCA000B22C40 /* TextFieldQuantityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC27B282AACDCA000B22C40 /* TextFieldQuantityView.swift */; };
 		AED85CD52A8B347B00E8B347 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED85CD42A8B347B00E8B347 /* BannerView.swift */; };
+		AEE12AAE2AAE5199002FE29D /* AddToCartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE12AAD2AAE5199002FE29D /* AddToCartView.swift */; };
 		AEF37BC12A891F710003F44E /* ShopHubViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF37BC02A891F710003F44E /* ShopHubViewModel.swift */; };
 /* End PBXBuildFile section */
 
@@ -66,6 +67,7 @@
 		AEBD622E2A99A1E10014C335 /* CartItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartItemView.swift; sourceTree = "<group>"; };
 		AEC27B282AACDCA000B22C40 /* TextFieldQuantityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldQuantityView.swift; sourceTree = "<group>"; };
 		AED85CD42A8B347B00E8B347 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
+		AEE12AAD2AAE5199002FE29D /* AddToCartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToCartView.swift; sourceTree = "<group>"; };
 		AEF37BC02A891F710003F44E /* ShopHubViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopHubViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -228,6 +230,7 @@
 			children = (
 				AEB27CA82A885795009E7A80 /* ToolbarView */,
 				4237B37F2A8AC5AD00C214AE /* TypeTagView.swift */,
+				AEE12AAD2AAE5199002FE29D /* AddToCartView.swift */,
 				AE3600662A9C467700E70E53 /* CartSubmissionView.swift */,
 				AEC27B282AACDCA000B22C40 /* TextFieldQuantityView.swift */,
 			);
@@ -353,6 +356,7 @@
 				42994BF12A9D4B39007248F0 /* MockCartView.swift in Sources */,
 				4271EC902A88729C00E2C85B /* SalesView.swift in Sources */,
 				AEF37BC12A891F710003F44E /* ShopHubViewModel.swift in Sources */,
+				AEE12AAE2AAE5199002FE29D /* AddToCartView.swift in Sources */,
 				AE3600672A9C467700E70E53 /* CartSubmissionView.swift in Sources */,
 				AEC27B292AACDCA000B22C40 /* TextFieldQuantityView.swift in Sources */,
 				4271EC8E2A8871EE00E2C85B /* Product.swift in Sources */,
@@ -504,7 +508,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ShopHub/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5H7526UKSL;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -534,7 +538,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ShopHub/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5H7526UKSL;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/ShopHub/ShopHub.xcodeproj/project.pbxproj
+++ b/ShopHub/ShopHub.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		AEB27CA72A87505B009E7A80 /* MenuTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB27CA62A87505B009E7A80 /* MenuTabView.swift */; };
 		AEB27CAA2A8857E5009E7A80 /* ToolBarStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB27CA92A8857E5009E7A80 /* ToolBarStyle.swift */; };
 		AEBD622F2A99A1E10014C335 /* CartItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBD622E2A99A1E10014C335 /* CartItemView.swift */; };
+		AEC27B292AACDCA000B22C40 /* TextFieldQuantityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC27B282AACDCA000B22C40 /* TextFieldQuantityView.swift */; };
 		AED85CD52A8B347B00E8B347 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED85CD42A8B347B00E8B347 /* BannerView.swift */; };
 		AEF37BC12A891F710003F44E /* ShopHubViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF37BC02A891F710003F44E /* ShopHubViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -63,6 +64,7 @@
 		AEB27CA62A87505B009E7A80 /* MenuTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTabView.swift; sourceTree = "<group>"; };
 		AEB27CA92A8857E5009E7A80 /* ToolBarStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBarStyle.swift; sourceTree = "<group>"; };
 		AEBD622E2A99A1E10014C335 /* CartItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartItemView.swift; sourceTree = "<group>"; };
+		AEC27B282AACDCA000B22C40 /* TextFieldQuantityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldQuantityView.swift; sourceTree = "<group>"; };
 		AED85CD42A8B347B00E8B347 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		AEF37BC02A891F710003F44E /* ShopHubViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopHubViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -227,6 +229,7 @@
 				AEB27CA82A885795009E7A80 /* ToolbarView */,
 				4237B37F2A8AC5AD00C214AE /* TypeTagView.swift */,
 				AE3600662A9C467700E70E53 /* CartSubmissionView.swift */,
+				AEC27B282AACDCA000B22C40 /* TextFieldQuantityView.swift */,
 			);
 			path = "Accessory Views";
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				4271EC902A88729C00E2C85B /* SalesView.swift in Sources */,
 				AEF37BC12A891F710003F44E /* ShopHubViewModel.swift in Sources */,
 				AE3600672A9C467700E70E53 /* CartSubmissionView.swift in Sources */,
+				AEC27B292AACDCA000B22C40 /* TextFieldQuantityView.swift in Sources */,
 				4271EC8E2A8871EE00E2C85B /* Product.swift in Sources */,
 				4271EC922A88753900E2C85B /* ProductView.swift in Sources */,
 				AE2B3B792A871EAE00889805 /* ShopHubApp.swift in Sources */,

--- a/ShopHub/ShopHub/User Interface/Accessory Views/AddToCartView.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/AddToCartView.swift
@@ -9,7 +9,21 @@ import SwiftUI
 
 struct AddToCartView: View {
     var body: some View {
-        Text("Hello, World!")
+        HStack {
+            Circle()
+                .stroke(.blue, lineWidth: 2.0)
+                .frame(width: 25)
+                .overlay {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.green)
+                }
+            Text("Added to cart")
+                .foregroundStyle(.white)
+                .font(.headline)
+                .bold()
+        }
+        .frame(width: 150, height: 35)
+        .background(Color.gray)
     }
 }
 

--- a/ShopHub/ShopHub/User Interface/Accessory Views/AddToCartView.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/AddToCartView.swift
@@ -1,0 +1,18 @@
+//
+//  AddToCartView.swift
+//  ShopHub
+//
+//  Created by Yongye Tan on 9/10/23.
+//
+
+import SwiftUI
+
+struct AddToCartView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+#Preview {
+    AddToCartView()
+}

--- a/ShopHub/ShopHub/User Interface/Accessory Views/AddToCartView.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/AddToCartView.swift
@@ -3,11 +3,17 @@
 //  ShopHub
 //
 //  Created by Yongye Tan on 9/10/23.
-//
+//  Source: https://www.hackingwithswift.com/books/ios-swiftui/triggering-events-repeatedly-using-a-timer
 
 import SwiftUI
 
 struct AddToCartView: View {
+    
+    @Binding var isAddToCartShown: Bool
+    
+    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    @State private var second: Int = 0 // keep track of how many seconds the view has been appeared
+
     var body: some View {
         HStack {
             Circle()
@@ -24,9 +30,19 @@ struct AddToCartView: View {
         }
         .frame(width: 150, height: 35)
         .background(Color.gray)
+        .onReceive(timer) { _ in
+            if second == 2 {
+                isAddToCartShown.toggle()
+                timer.upstream.connect().cancel()
+            }
+            second += 1
+        }
     }
 }
 
 #Preview {
-    AddToCartView()
+    let products: [Product] = Bundle.main.decode("ProductList.json")
+    let product: Product = products[1]
+    return ProductDetailView(product: product)
+        .environmentObject(CartViewModel())
 }

--- a/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
@@ -1,0 +1,34 @@
+//
+//  TextFieldQuantityView.swift
+//  ShopHub
+//
+//  Created by Yongye Tan on 9/9/23.
+//
+
+import SwiftUI
+
+struct TextFieldQuantityView: View {
+    
+    @Binding var value: Int
+    @FocusState var focusState: Bool
+    
+    init(value: Binding<Int>, focusState: FocusState<Bool>) {
+        _value = value
+        _focusState = focusState
+    }
+    
+    var body: some View {
+        TextField("1", value: $value, format: .number)
+            .focused($focusState)
+            .multilineTextAlignment(.center)
+            .textFieldStyle(.roundedBorder)
+            .frame(width: 55)
+            .keyboardType(.numberPad) // super weird log: unable to simultaneously satisfy constraints, seems like a bug in swiftui, more to find: https://stackoverflow.com/questions/66082340/swiftui-unable-to-simultaneously-satisfy-constraints-when-focus-on-textfield-a
+            .onChange(of: value) { oldValue, newValue in
+                if value > 999 {
+                    value = oldValue
+                }
+            } // onChange only accepts 2 parameter or 0, more to find: https://useyourloaf.com/blog/swiftui-onchange-deprecation/
+    }
+    
+}

--- a/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
@@ -12,23 +12,24 @@ struct TextFieldQuantityView: View {
     @Binding var value: Int
     @FocusState var focusState: Bool
     
-    init(value: Binding<Int>, focusState: FocusState<Bool>) {
+    let width: CGFloat
+    
+    init(value: Binding<Int>, focusState: FocusState<Bool>, width: CGFloat = 53) {
         // since we pass value and focusState as binding variable, we need to get the wrapped value of these binding variable, therefore having the underscore "opens" the Binding for you to change its wrapped value. More to find: https://stackoverflow.com/a/71237371/22303588
         self._value = value
         self._focusState = focusState
+        self.width = width
     }
     
     var body: some View {
-        TextField("1", value: $value, format: .number)
-            .frame(width: 55)
+        TextField(String(value), value: $value, format: .number)
+            .frame(width: width)
             .focused($focusState)
             .multilineTextAlignment(.center)
             .textFieldStyle(.roundedBorder)
             .keyboardType(.numberPad) // super weird log: unable to simultaneously satisfy constraints, seems like a bug in swiftui, more to find: https://stackoverflow.com/questions/66082340/swiftui-unable-to-simultaneously-satisfy-constraints-when-focus-on-textfield-a
             .onChange(of: value) { oldValue, newValue in
-                if value > 999 {
-                    value = oldValue
-                }
+                value = value > 999 ? oldValue : value
             } // onChange only accepts 2 parameter or 0, more to find: https://useyourloaf.com/blog/swiftui-onchange-deprecation/
     }
     

--- a/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
@@ -29,7 +29,7 @@ struct TextFieldQuantityView: View {
             .textFieldStyle(.roundedBorder)
             .keyboardType(.numberPad) // super weird log: unable to simultaneously satisfy constraints, seems like a bug in swiftui, more to find: https://stackoverflow.com/questions/66082340/swiftui-unable-to-simultaneously-satisfy-constraints-when-focus-on-textfield-a
             .onChange(of: value) { oldValue, newValue in
-                value = value > 999 ? oldValue : value
+                value = value > 999 ? oldValue : (value == 0 ? 1 : value)
             } // onChange only accepts 2 parameter or 0, more to find: https://useyourloaf.com/blog/swiftui-onchange-deprecation/
     }
     

--- a/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/TextFieldQuantityView.swift
@@ -13,16 +13,17 @@ struct TextFieldQuantityView: View {
     @FocusState var focusState: Bool
     
     init(value: Binding<Int>, focusState: FocusState<Bool>) {
-        _value = value
-        _focusState = focusState
+        // since we pass value and focusState as binding variable, we need to get the wrapped value of these binding variable, therefore having the underscore "opens" the Binding for you to change its wrapped value. More to find: https://stackoverflow.com/a/71237371/22303588
+        self._value = value
+        self._focusState = focusState
     }
     
     var body: some View {
         TextField("1", value: $value, format: .number)
+            .frame(width: 55)
             .focused($focusState)
             .multilineTextAlignment(.center)
             .textFieldStyle(.roundedBorder)
-            .frame(width: 55)
             .keyboardType(.numberPad) // super weird log: unable to simultaneously satisfy constraints, seems like a bug in swiftui, more to find: https://stackoverflow.com/questions/66082340/swiftui-unable-to-simultaneously-satisfy-constraints-when-focus-on-textfield-a
             .onChange(of: value) { oldValue, newValue in
                 if value > 999 {

--- a/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
+++ b/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
@@ -9,6 +9,8 @@ import Foundation
 import SwiftUI
 
 struct MenuTabView: View {
+    
+    @EnvironmentObject var shoppingCart: CartViewModel
     @StateObject var menuViewModel: MenuTabViewModel = MenuTabViewModel()
     
     var body: some View {
@@ -17,6 +19,7 @@ struct MenuTabView: View {
                 .tabItem {
                     tab.label
                 }
+                .badge(tab == .cart ? shoppingCart.totalQuantities : 0)
         }
     }
 }

--- a/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
+++ b/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
@@ -19,7 +19,9 @@ struct MenuTabView: View {
                 .tabItem {
                     tab.label
                 }
-                .badge(tab == .cart ? shoppingCart.totalQuantities : 0)
+                .badge(tab == .cart ?
+                       shoppingCart.totalQuantities < 99 ? String(shoppingCart.totalQuantities) : "99+"
+                       : nil)
         }
     }
 }

--- a/ShopHub/ShopHub/User Interface/Page Views/Cart/CartItemView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Cart/CartItemView.swift
@@ -12,9 +12,16 @@ struct CartItemView: View {
     // Environment object
     @EnvironmentObject var shoppingCart: CartViewModel
     
-    // Parameters
-    let product: Product
-    let quantity: Int
+    // Internal State
+    @State private var product: Product
+    @State private var quantity: Int
+    @FocusState private var isQuantityFocused: Bool
+    
+    init(product: Product, quantity: Int) {
+        // becuase we passed product and quantity from the parent view as parameters, but we want to modify the internal state and update them as State, we have to set the initial value of these as the state parameters
+        self._product = State(initialValue: product)
+        self._quantity = State(initialValue: quantity)
+    }
     
     private var totalPrice: Double {
         let singlePrice = product.price
@@ -61,9 +68,7 @@ struct CartItemView: View {
                         }
                         .disabled(shoppingCart.getQuantity(of: product) == 1)
                         
-                        Text("\(shoppingCart.getQuantity(of: product))")
-                            .minimumScaleFactor(quantity > 9 ? 0.5 : 1)
-                            .lineLimit(1)
+                        TextFieldQuantityView(value: $quantity, focusState: _isQuantityFocused)
                         
                         Button {
                             shoppingCart.incrementQuantity(of: product)
@@ -82,6 +87,9 @@ struct CartItemView: View {
         .padding([.leading, .trailing, .top], 10)
         .background(Color(.systemBackground))
         .cornerRadius(20)
+        .onChange(of: quantity) {
+            shoppingCart.update(product: product, with: quantity)
+        }
         .swipeActions(edge: .leading, allowsFullSwipe: false) {
             Button(role: .destructive) {
                 shoppingCart.delete(product: product)

--- a/ShopHub/ShopHub/User Interface/Page Views/Cart/CartItemView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Cart/CartItemView.swift
@@ -61,27 +61,25 @@ struct CartItemView: View {
                     
                     HStack {
                         Button {
-                            shoppingCart.decrementQuantity(of: product)
+                            quantity -= 1
                         } label: {
                             Image(systemName: "minus.square")
                             
                         }
-                        .disabled(shoppingCart.getQuantity(of: product) == 1)
+                        .disabled(quantity == 1)
                         
                         TextFieldQuantityView(value: $quantity, focusState: _isQuantityFocused)
                         
                         Button {
-                            shoppingCart.incrementQuantity(of: product)
-                            
+                            quantity += 1
                         } label: {
                             Image(systemName: "plus.square")
                         }
-                        .disabled(shoppingCart.getQuantity(of: product) == 999)
+                        .disabled(quantity == 999)
                     }
                     .buttonStyle(.borderless)
                                                 
                 }
-                .foregroundStyle(.blue)
             }
         }
         .padding([.leading, .trailing, .top], 10)

--- a/ShopHub/ShopHub/User Interface/Page Views/Cart/CartListView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Cart/CartListView.swift
@@ -60,6 +60,7 @@ struct CartListView: View {
                 }
                 .listStyle(.insetGrouped)
                 .blur(radius: showSubmissionView ? 8 : 0)
+                .disabled(showSubmissionView)
                 
                 
                 if showSubmissionView {

--- a/ShopHub/ShopHub/User Interface/Page Views/Cart/CartListView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Cart/CartListView.swift
@@ -31,6 +31,8 @@ struct CartListView: View {
                                              quantity: cart.products[product] ?? 0)
                                 
                             }
+                            .listRowInsets(.init(top: 5, leading: 10, bottom: 5, trailing: 10)) // add padding to each list item to make the view less tight
+    
                         } header: {
                             Text(cart.sectionHeader(type))
                                 .font(.subheadline)

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -14,6 +14,7 @@ struct ProductDetailView: View {
     
     // Internal State
     @State private var quantity = 1
+    @State private var isAddButtonPressed = false
     
     @EnvironmentObject var shoppingCart: CartViewModel
 
@@ -93,6 +94,7 @@ struct ProductDetailView: View {
                 .padding()
                 
                 Button {
+                    isAddButtonPressed.toggle()
                     shoppingCart.add(product: product, with: quantity)
                 } label: {
                     Text("Add to cart")
@@ -100,6 +102,7 @@ struct ProductDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .padding()
+                .sensoryFeedback(.success, trigger: isAddButtonPressed) // add haptic effect when item adds to cart
             }
         }
         .navigationTitle("Product Details")

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -14,6 +14,7 @@ struct ProductDetailView: View {
     
     // Internal State
     @State private var quantity = 1
+    @State private var isAddButtonPressed = false
     @FocusState var isQuantityFocused: Bool
     
     @EnvironmentObject var shoppingCart: CartViewModel
@@ -40,7 +41,7 @@ struct ProductDetailView: View {
                 
                 Divider()
                 
-                // MARK: name and type stack
+                // MARK: Name and type stack
                 HStack {
 
                     TypeTagView(productType: product.type, 
@@ -56,14 +57,14 @@ struct ProductDetailView: View {
                 }
                 .padding()
                 
-                // MARK: description
+                // MARK: Description
                 Text(product.description ?? "N/A")
                     .multilineTextAlignment(.leading)
                     .font(.body)
                     .fontWeight(.light)
                     .padding()
                 
-                // MARK: Price && quantity
+                // MARK: Price && Quantity
                 HStack {
                     
                     Text(totalPrice, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -80,17 +80,7 @@ struct ProductDetailView: View {
                         }
                         .disabled(quantity == 1)
                         
-                        TextField("1", value: $quantity, format: .number)
-                            .focused($isQuantityFocused)
-                            .multilineTextAlignment(.center)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 55)
-                            .keyboardType(.numberPad) // super weird log: unable to simultaneously satisfy constraints, seems like a bug in swiftui, more to find: https://stackoverflow.com/questions/66082340/swiftui-unable-to-simultaneously-satisfy-constraints-when-focus-on-textfield-a
-                            .onChange(of: quantity) { oldValue, newValue in
-                                if quantity > 999 {
-                                    quantity = oldValue
-                                }
-                            } // onChange only accepts 2 parameter or 0, more to find: https://useyourloaf.com/blog/swiftui-onchange-deprecation/
+                        TextFieldQuantityView(value: $quantity, focusState: _isQuantityFocused)
                         
                         Button {
                             quantity += 1

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -14,6 +14,7 @@ struct ProductDetailView: View {
     
     // Internal State
     @State private var quantity = 1
+    @FocusState var isQuantityFocused: Bool
     
     @EnvironmentObject var shoppingCart: CartViewModel
 
@@ -79,7 +80,12 @@ struct ProductDetailView: View {
                         }
                         .disabled(quantity == 1)
                         
-                        Text("\(quantity)")
+                        TextField("1", value: $quantity, format: .number)
+                            .focused($isQuantityFocused)
+                            .multilineTextAlignment(.center)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 55)
+                            .keyboardType(.numberPad)
                         
                         Button {
                             quantity += 1
@@ -104,12 +110,24 @@ struct ProductDetailView: View {
         }
         .navigationTitle("Product Details")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            // add a submit button to disable the focus
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button {
+                    isQuantityFocused = false
+                } label: {
+                    Text("Submit").foregroundStyle(.blue)
+                }
+            }
+            
+        }
     }
 }
 
-//#Preview("Clothing") {
-//    let products: [Product] = Bundle.main.decode("ProductList.json")
-//    let product: Product = products[1]
-//    return ProductDetailView(product: product)
-//}
+#Preview("Clothing") {
+    let products: [Product] = Bundle.main.decode("ProductList.json")
+    let product: Product = products[1]
+    return ProductDetailView(product: product)
+}
 

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -102,16 +102,15 @@ struct ProductDetailView: View {
                         Text("Add to cart")
                             .frame(maxWidth: .infinity)
                     }
-                    .buttonStyle(.borderedProminent)
                     .padding()
+                    .buttonStyle(.borderedProminent)
                     .sensoryFeedback(.success, trigger: isAddButtonPressed) // add haptic effect when item adds to cart
                 }
-                .blur(radius: isAddButtonPressed ? 0.5 : 0)
+                .blur(radius: isAddButtonPressed ? 2 : 0)
                 .disabled(isAddButtonPressed)
                 
                 if isAddButtonPressed {
-                    Color.clear
-                    AddToCartView()
+                    AddToCartView(isAddToCartShown: $isAddButtonPressed)
                 }
             }
         }
@@ -124,7 +123,8 @@ struct ProductDetailView: View {
                 Button {
                     isQuantityFocused = false
                 } label: {
-                    Text("Submit").foregroundStyle(.blue)
+                    Text("Submit")
+                        .foregroundStyle(.blue)
                 }
             }
             

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -85,7 +85,12 @@ struct ProductDetailView: View {
                             .multilineTextAlignment(.center)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 55)
-                            .keyboardType(.numberPad)
+                            .keyboardType(.numberPad) // super weird log: unable to simultaneously satisfy constraints, seems like a bug in swiftui, more to find: https://stackoverflow.com/questions/66082340/swiftui-unable-to-simultaneously-satisfy-constraints-when-focus-on-textfield-a
+                            .onChange(of: quantity) { oldValue, newValue in
+                                if quantity > 999 {
+                                    quantity = oldValue
+                                }
+                            } // onChange only accepts 2 parameter or 0, more to find: https://useyourloaf.com/blog/swiftui-onchange-deprecation/
                         
                         Button {
                             quantity += 1

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -29,81 +29,90 @@ struct ProductDetailView: View {
     
     var body: some View {
         NavigationStack {
-            VStack {
-                // MARK: Top image
-                ZStack {
-                    Image("\(product.image)")
-                        .resizable(resizingMode: .stretch)
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 200, height: 200)
-                        .clipShape(RoundedRectangle(cornerRadius: 20))
-                }
-                
-                Divider()
-                
-                // MARK: Name and type stack
-                HStack {
-
-                    TypeTagView(productType: product.type, 
-                                backgroundColor: .red,
-                                fontSize: 12)
-                    
-                    Spacer()
-                    
-                    Text(product.name)
-                        .fontWeight(.bold)
-                        .font(.system(size: 20))
-
-                }
-                .padding()
-                
-                // MARK: Description
-                Text(product.description ?? "N/A")
-                    .multilineTextAlignment(.leading)
-                    .font(.body)
-                    .fontWeight(.light)
-                    .padding()
-                
-                // MARK: Price && Quantity
-                HStack {
-                    
-                    Text(totalPrice, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
-                        .font(.system(size: 20))
-                        .fontWeight(.heavy)
-                    
-                    Spacer()
-                    
-                    HStack {
-                        Button {
-                            quantity -= 1
-                        } label: {
-                            Image(systemName: "minus.square")
-                        }
-                        .disabled(quantity == 1)
-                        
-                        TextFieldQuantityView(value: $quantity, focusState: _isQuantityFocused)
-                        
-                        Button {
-                            quantity += 1
-                        } label: {
-                            Image(systemName: "plus.square")
-                        }
+            ZStack {
+                VStack {
+                    // MARK: Top image
+                    ZStack {
+                        Image("\(product.image)")
+                            .resizable(resizingMode: .stretch)
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 200, height: 200)
+                            .clipShape(RoundedRectangle(cornerRadius: 20))
                     }
-                    .font(.system(size: 20))
-                    .fontWeight(.medium)
+                    
+                    Divider()
+                    
+                    // MARK: Name and type stack
+                    HStack {
+                        
+                        TypeTagView(productType: product.type,
+                                    backgroundColor: .red,
+                                    fontSize: 12)
+                        
+                        Spacer()
+                        
+                        Text(product.name)
+                            .fontWeight(.bold)
+                            .font(.system(size: 20))
+                        
+                    }
+                    .padding()
+                    
+                    // MARK: Description
+                    Text(product.description ?? "N/A")
+                        .multilineTextAlignment(.leading)
+                        .font(.body)
+                        .fontWeight(.light)
+                        .padding()
+                    
+                    // MARK: Price && Quantity
+                    HStack {
+                        
+                        Text(totalPrice, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                            .font(.system(size: 20))
+                            .fontWeight(.heavy)
+                        
+                        Spacer()
+                        
+                        HStack {
+                            Button {
+                                quantity -= 1
+                            } label: {
+                                Image(systemName: "minus.square")
+                            }
+                            .disabled(quantity == 1)
+                            
+                            TextFieldQuantityView(value: $quantity, focusState: _isQuantityFocused)
+                            
+                            Button {
+                                quantity += 1
+                            } label: {
+                                Image(systemName: "plus.square")
+                            }
+                        }
+                        .font(.system(size: 20))
+                        .fontWeight(.medium)
+                    }
+                    .padding()
+                    
+                    Button {
+                        isAddButtonPressed.toggle()
+                        shoppingCart.add(product: product, with: quantity)
+                    } label: {
+                        Text("Add to cart")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .padding()
+                    .sensoryFeedback(.success, trigger: isAddButtonPressed) // add haptic effect when item adds to cart
                 }
-                .padding()
+                .blur(radius: isAddButtonPressed ? 0.5 : 0)
+                .disabled(isAddButtonPressed)
                 
-                Button {
-                    isAddButtonPressed.toggle()
-                    shoppingCart.add(product: product, with: quantity)
-                } label: {
-                    Text("Add to cart")
-                        .frame(maxWidth: .infinity)
+                if isAddButtonPressed {
+                    Color.clear
+                    AddToCartView()
                 }
-                .buttonStyle(.borderedProminent)
-                .padding()
-                .sensoryFeedback(.success, trigger: isAddButtonPressed) // add haptic effect when item adds to cart
             }
         }
         .navigationTitle("Product Details")
@@ -127,5 +136,6 @@ struct ProductDetailView: View {
     let products: [Product] = Bundle.main.decode("ProductList.json")
     let product: Product = products[1]
     return ProductDetailView(product: product)
+        .environmentObject(CartViewModel())
 }
 

--- a/ShopHub/ShopHub/ViewModels/CartViewModel/CartViewModel.swift
+++ b/ShopHub/ShopHub/ViewModels/CartViewModel/CartViewModel.swift
@@ -59,7 +59,7 @@ extension CartViewModel {
         products.isEmpty
     }
     
-    /// Get and manipulate the quantity of product
+    /// Get the quantity of the product
     func getQuantity(of product: Product) -> Int {
         products[product] ?? -1
     }
@@ -74,19 +74,6 @@ extension CartViewModel {
     /// Calculate the total quantities of all the products in the cart
     var totalQuantities: Int {
         products.values.reduce(0, +)
-    }
-    
-
-    func incrementQuantity(of product: Product) {
-        if let currentQuantity = products[product], currentQuantity <= 999 {
-            products[product]! += 1
-        }
-    }
-    
-    func decrementQuantity(of product: Product) {
-        if let currentQuantity = products[product], currentQuantity > 0 {
-            products[product]! -= 1
-        }
     }
     
     /// Calculate the total price of all the products in the cart

--- a/ShopHub/ShopHub/ViewModels/CartViewModel/CartViewModel.swift
+++ b/ShopHub/ShopHub/ViewModels/CartViewModel/CartViewModel.swift
@@ -49,6 +49,11 @@ extension CartViewModel {
         }
     }
     
+    /// update the product quantity to local shopping cart
+    func update(product: Product, with count: Int) {
+        products[product] = count
+    }
+    
     /// A `Boolean` value that indicates whether the shopping cart is empty.
     func isEmpty() -> Bool {
         products.isEmpty

--- a/ShopHub/ShopHub/ViewModels/CartViewModel/Cartable.swift
+++ b/ShopHub/ShopHub/ViewModels/CartViewModel/Cartable.swift
@@ -15,6 +15,13 @@ protocol Cartable {
     /// adds a specific product to the local shopping cart with quantity.
     func add(product: Product, with: Int)
     
-    // remove products from the local shopping cart.
-//    func remove
+    /// remove product from the local shopping cart.
+    func delete(product: Product)
+    
+    /// update the product quantity to local shopping cart.
+    func update(product: Product, with: Int)
+    
+    /// get the quantity of product
+    func getQuantity(of product: Product) -> Int
+    
 }


### PR DESCRIPTION
Add a textfield for user desired numbers along with a numeric pad and focus state when submit button is pressed. 
- [ ] Need to fix this bug ASAP: https://github.com/algebra2boy/ShopHub/issues/32
<img width="329" alt="Screenshot 2023-09-09 at 12 56 57 PM" src="https://github.com/algebra2boy/ShopHub/assets/103079472/8b89a8c2-b448-4223-a290-fb3c7728f438">

