### PR TITLE
Add badge number to cartview

### DIFF
--- a/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
+++ b/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
@@ -9,6 +9,8 @@ import Foundation
 import SwiftUI
 
 struct MenuTabView: View {
+    
+    @EnvironmentObject var shoppingCart: CartViewModel
     @StateObject var menuViewModel: MenuTabViewModel = MenuTabViewModel()
     
     var body: some View {
@@ -17,6 +19,7 @@ struct MenuTabView: View {
                 .tabItem {
                     tab.label
                 }
+                .badge(tab == .cart ? shoppingCart.totalQuantities : 0)
         }
     }
 }

--- a/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
+++ b/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
@@ -19,7 +19,9 @@ struct MenuTabView: View {
                 .tabItem {
                     tab.label
                 }
-                .badge(tab == .cart ? shoppingCart.totalQuantities : 0)
+                .badge(tab == .cart ?
+                       shoppingCart.totalQuantities < 99 ? String(shoppingCart.totalQuantities) : "99+"
+                       : nil)
         }
     }
 }


### PR DESCRIPTION
This PR adds a badge number to cart view. The badge number shows how many product the user has added to their local shopping cart. When badge number is zero, the badge number will not be visible. 
<img width="738" alt="Screenshot 2023-09-09 at 2 06 53 PM" src="https://github.com/algebra2boy/ShopHub/assets/103079472/7cd8a201-b62e-4836-8241-901438fa77cd">
