### PR TITLE
Haptic effect to notify an item has been added

### DIFF
--- a/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
+++ b/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
@@ -9,6 +9,8 @@ import Foundation
 import SwiftUI
 
 struct MenuTabView: View {
+    
+    @EnvironmentObject var shoppingCart: CartViewModel
     @StateObject var menuViewModel: MenuTabViewModel = MenuTabViewModel()
     
     var body: some View {
@@ -17,6 +19,7 @@ struct MenuTabView: View {
                 .tabItem {
                     tab.label
                 }
+                .badge(tab == .cart ? shoppingCart.totalQuantities : 0)
         }
     }
 }

--- a/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
+++ b/ShopHub/ShopHub/User Interface/Menu Navigation/MenuTabView.swift
@@ -19,7 +19,9 @@ struct MenuTabView: View {
                 .tabItem {
                     tab.label
                 }
-                .badge(tab == .cart ? shoppingCart.totalQuantities : 0)
+                .badge(tab == .cart ?
+                       shoppingCart.totalQuantities < 99 ? String(shoppingCart.totalQuantities) : "99+"
+                       : nil)
         }
     }
 }

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -14,6 +14,7 @@ struct ProductDetailView: View {
     
     // Internal State
     @State private var quantity = 1
+    @State private var isAddButtonPressed = false
     
     @EnvironmentObject var shoppingCart: CartViewModel
 
@@ -93,6 +94,7 @@ struct ProductDetailView: View {
                 .padding()
                 
                 Button {
+                    isAddButtonPressed.toggle()
                     shoppingCart.add(product: product, with: quantity)
                 } label: {
                     Text("Add to cart")
@@ -100,6 +102,7 @@ struct ProductDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .padding()
+                .sensoryFeedback(.success, trigger: isAddButtonPressed) // add haptic effect when item adds to cart
             }
         }
         .navigationTitle("Product Details")


### PR DESCRIPTION
In iOS 17, SwiftUI introduced a new haptic effect called `sensoryFeedback` without the need to use the UINotificationGenerator from `UIKit`. When an item is added from their product detail view to their local shopping cart, a haptic vibrating effect will be shown. Please run it on the physical iPhone.