### PR TITLE
Add a custom navigation Bar Button + Comparable on Product

### DIFF
--- a/ShopHub/ShopHub.xcodeproj/project.pbxproj
+++ b/ShopHub/ShopHub.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		AE2B3B7D2A871EAF00889805 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AE2B3B7C2A871EAF00889805 /* Assets.xcassets */; };
 		AE2B3B802A871EAF00889805 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AE2B3B7F2A871EAF00889805 /* Preview Assets.xcassets */; };
 		AE3600672A9C467700E70E53 /* CartSubmissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3600662A9C467700E70E53 /* CartSubmissionView.swift */; };
+		AE5FAA402AB79787004D1EFA /* NavigationCustomBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5FAA3F2AB79787004D1EFA /* NavigationCustomBackButton.swift */; };
 		AEAC80172A9AFEDA0074F0CC /* Cartable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEAC80162A9AFEDA0074F0CC /* Cartable.swift */; };
 		AEAC801A2A9C1DBA0074F0CC /* CartTranscationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEAC80192A9C1DBA0074F0CC /* CartTranscationView.swift */; };
 		AEB27C9F2A874D74009E7A80 /* ProductsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB27C9E2A874D74009E7A80 /* ProductsView.swift */; };
@@ -57,6 +58,7 @@
 		AE2B3B7C2A871EAF00889805 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AE2B3B7F2A871EAF00889805 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AE3600662A9C467700E70E53 /* CartSubmissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartSubmissionView.swift; sourceTree = "<group>"; };
+		AE5FAA3F2AB79787004D1EFA /* NavigationCustomBackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCustomBackButton.swift; sourceTree = "<group>"; };
 		AEAC80162A9AFEDA0074F0CC /* Cartable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cartable.swift; sourceTree = "<group>"; };
 		AEAC80192A9C1DBA0074F0CC /* CartTranscationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartTranscationView.swift; sourceTree = "<group>"; };
 		AEB27C9E2A874D74009E7A80 /* ProductsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsView.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 		AEB27CA82A885795009E7A80 /* ToolbarView */ = {
 			isa = PBXGroup;
 			children = (
+				AE5FAA3F2AB79787004D1EFA /* NavigationCustomBackButton.swift */,
 				AEB27CA92A8857E5009E7A80 /* ToolBarStyle.swift */,
 			);
 			path = ToolbarView;
@@ -363,6 +366,7 @@
 				4271EC922A88753900E2C85B /* ProductView.swift in Sources */,
 				AE2B3B792A871EAE00889805 /* ShopHubApp.swift in Sources */,
 				AEB27CAA2A8857E5009E7A80 /* ToolBarStyle.swift in Sources */,
+				AE5FAA402AB79787004D1EFA /* NavigationCustomBackButton.swift in Sources */,
 				4271EC882A8871BE00E2C85B /* Bundle+Decode.swift in Sources */,
 				4237B3802A8AC5AD00C214AE /* TypeTagView.swift in Sources */,
 				AEB27CA12A874D86009E7A80 /* CartView.swift in Sources */,

--- a/ShopHub/ShopHub/Models/Product.swift
+++ b/ShopHub/ShopHub/Models/Product.swift
@@ -20,3 +20,19 @@ struct Product: Codable, Identifiable, Hashable {
     var image: String
     
 }
+
+extension Product: Comparable {
+    /// Conformation to `Comparable` protocol to allow for `sorted()` operations.
+    static func <(lhs: Product, rhs: Product) -> Bool {
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        } else if lhs.price != rhs.price {
+            return lhs.price < rhs.price
+        } else if lhs.type != rhs.type {
+            return lhs.type < rhs.type
+        }
+        return lhs.image < rhs.image
+    }
+    
+}
+

--- a/ShopHub/ShopHub/User Interface/Accessory Views/ToolbarView/NavigationCustomBackButton.swift
+++ b/ShopHub/ShopHub/User Interface/Accessory Views/ToolbarView/NavigationCustomBackButton.swift
@@ -1,0 +1,37 @@
+//
+//  NavigationCustomBackButton.swift
+//  ShopHub
+//
+//  Created by Yongye Tan on 9/17/23.
+//
+
+import SwiftUI
+
+struct NavigationCustomBarBackButton: ViewModifier {
+    
+    @Environment(\.dismiss) var dismiss
+    
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "arrow.left")
+                            .foregroundStyle(Color.black)
+                            .font(.title3)
+                    }
+                }
+            }
+        
+    }
+}
+
+extension View {
+    @ViewBuilder
+    public func navigationCustomBarBackButton() -> some View {
+        self.modifier(NavigationCustomBarBackButton())
+    }
+}

--- a/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
+++ b/ShopHub/ShopHub/User Interface/Page Views/Products/Sale/ProductDetailView.swift
@@ -120,6 +120,8 @@ struct ProductDetailView: View {
         }
         .navigationTitle("Product Details")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)  // hide the default < back button
+        .navigationCustomBarBackButton()
         .toolbar {
             // add a submit button to disable the focus
             ToolbarItemGroup(placement: .keyboard) {

--- a/ShopHub/ShopHub/ViewModels/CartViewModel/CartViewModel.swift
+++ b/ShopHub/ShopHub/ViewModels/CartViewModel/CartViewModel.swift
@@ -29,7 +29,7 @@ class CartViewModel: ObservableObject, Cartable {
     func sectionContent(_ type: String) -> [Product] {
         Array(products
             .filter { $0.key.type == type }
-            .keys)
+            .keys).sorted()
     }
     
     init() {


### PR DESCRIPTION
Adding a custom nav bar button because the default contains the word "back", and I think we could get rid of the unnecessary word, and make the arrow look even better with our own style.

<img width="182" alt="Screenshot 2023-09-17 at 4 36 19 PM" src="https://github.com/algebra2boy/ShopHub/assets/103079472/98858908-6e28-4574-8613-f8835b74bc3b">
